### PR TITLE
Add multithreaded tests and refactor timer manager

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,33 +1,50 @@
+"""Timer management utilities backed by :class:`DataManager`."""
 
 from typing import Any, Dict
-from data import DataManager
 import time
-PAUSED="paused"
-RUNNING="running"
-NOT_SET=-1
+
+from data import DataManager
+
+
+PAUSED = "paused"
+RUNNING = "running"
+NOT_SET = -1.0
+
 
 class TimerManager:
-    
-    def __init__(self) -> None:
+    """Manage simple timers stored in a SQLite database."""
+
+    def __init__(self, database_path: str = "data.db") -> None:
+        """Create a new ``TimerManager``.
+
+        Parameters
+        ----------
+        database_path: str
+            Path to the SQLite database used for storing timers.
+        """
+
         self.dm = DataManager(
             column_type_dict={
-                "duration":float, # store time in seconds
-                "start_time":float,  # timestamp when the timer was started
-                "end_time":float,    # timestamp when the timer was ended
-                "status":str,        # status of the timer (e.g., "running", "paused", "stopped")
-                "name":str,           # name of the timer
-            }
-                ,database_path="data.db"
+                "duration": float,
+                "start_time": float,
+                "end_time": float,
+                "status": str,
+                "name": str,
+            },
+            database_path=database_path,
         )
-        self.watching_tasks= self.dm.find_item({"status":RUNNING})
+        self.watching_tasks = self.dm.find_item({"status": RUNNING})
+
     def is_timer_exists(self, timer_id: int) -> bool:
+        """Return ``True`` if ``timer_id`` exists in the database."""
         if not isinstance(timer_id, int) or timer_id <= 0:
             raise ValueError("Timer ID must be a positive integer.")
-        timers=self.dm.find_item({"id": timer_id})
-        if len(timers) ==0: return False
-        elif len(timers) ==1: return True
-        else:
-            raise RuntimeError("Multiple timers found with the same ID, which is unexpected.")
+        try:
+            self.dm.get_attr(timer_id, "name")
+            return True
+        except ValueError:
+            return False
+
     def is_timer_running(self, timer_id: int) -> bool:
         if not self.is_timer_exists(timer_id):
             raise ValueError("Timer with this ID does not exist.")
@@ -35,9 +52,10 @@ class TimerManager:
         duration = self.dm.get_attr(timer_id, "duration")
         start_time = self.dm.get_attr(timer_id, "start_time")
         end_time = self.dm.get_attr(timer_id, "end_time")
-        if end_time-duration!= start_time:
+        if end_time - duration != start_time:
             raise RuntimeError("The timer's start and end times do not match the duration.")
         return status == RUNNING
+
     def is_timer_paused(self, timer_id: int) -> bool:
         if not self.is_timer_exists(timer_id):
             raise ValueError("Timer with this ID does not exist.")
@@ -50,12 +68,7 @@ class TimerManager:
         assert start_time == NOT_SET
         assert end_time == NOT_SET
         return True
-    # def get_timer_attr(self, timer_id: int, attr: str) -> Any:
-    #     if not isinstance(timer_id, int) or timer_id <= 0:
-    #         raise ValueError("Timer ID must be a positive integer.")
-    #     if not self.is_timer_exists(timer_id):
-    #         raise ValueError("Timer with this ID does not exist.")
-    #     return self.dm.get_attr(timer_id, attr)
+
     def create_timer(self, name: str, duration: int) -> int:
         if not isinstance(name, str) or not isinstance(duration, int):
             raise ValueError("Name must be a string and duration must be an integer.")
@@ -65,27 +78,32 @@ class TimerManager:
             raise ValueError("Name cannot be empty.")
         if len(name) > 100:
             raise ValueError("Name cannot exceed 100 characters.")
-        this_moment=time.time()        
-        return self.dm.add_item({
-            "name": name,
-            "duration": duration,
-            "start_time":this_moment,
-            "end_time": this_moment+duration,
-            "status": RUNNING
-        })
+        this_moment = time.time()
+        float_duration = float(duration)
+        return self.dm.add_item(
+            {
+                "name": name,
+                "duration": float_duration,
+                "start_time": this_moment,
+                "end_time": this_moment + float_duration,
+                "status": RUNNING,
+            }
+        )
+
     def rm_timer(self, timer_id: int) -> None:
         assert self.is_timer_exists(timer_id)
         self.dm.rm_item(timer_id)
+
     def pause_timer(self, timer_id: int) -> None:
         assert self.is_timer_exists(timer_id)
         assert self.is_timer_running(timer_id)
-        start_time=self.dm.get_attr(timer_id,"start_time")
-        end_time=self.dm.get_attr(timer_id,"end_time")
-        duration=self.dm.get_attr(timer_id,"duration")
-        self.dm.set_attr(timer_id, "duration", time.time()-end_time)
+        end_time = self.dm.get_attr(timer_id, "end_time")
+        remaining = end_time - time.time()
+        self.dm.set_attr(timer_id, "duration", remaining)
         self.dm.set_attr(timer_id, "start_time", NOT_SET)
         self.dm.set_attr(timer_id, "end_time", NOT_SET)
         self.dm.set_attr(timer_id, "status", PAUSED)
+
     def resume_timer(self, timer_id: int) -> None:
         assert self.is_timer_exists(timer_id)
         assert self.is_timer_paused(timer_id)
@@ -97,6 +115,7 @@ class TimerManager:
         self.dm.set_attr(timer_id, "start_time", start_time)
         self.dm.set_attr(timer_id, "end_time", end_time)
         self.dm.set_attr(timer_id, "status", RUNNING)
+
     def get_timer_info(self, timer_id: int) -> Dict[str, Any]:
         if not self.is_timer_exists(timer_id):
             raise ValueError("Timer with this ID does not exist.")
@@ -106,6 +125,6 @@ class TimerManager:
             "duration": self.dm.get_attr(timer_id, "duration"),
             "start_time": self.dm.get_attr(timer_id, "start_time"),
             "end_time": self.dm.get_attr(timer_id, "end_time"),
-            "status": self.dm.get_attr(timer_id, "status")
+            "status": self.dm.get_attr(timer_id, "status"),
         }
-    
+

--- a/test_thread_safety.py
+++ b/test_thread_safety.py
@@ -1,0 +1,82 @@
+"""Thread-safety tests for :mod:`data` and :class:`TimerManager`."""
+
+import threading
+from typing import Dict
+
+from data import DataManager
+from main import TimerManager
+
+
+# ---------------------------------------------------------------------------
+# DataManager multi-thread tests
+
+COLUMN_TYPES: Dict[str, type] = {
+    "name": str,
+    "count": int,
+    "active": bool,
+    "rating": float,
+    "tags": list,
+    "settings": dict,
+}
+
+
+def _dm_worker(idx: int, db_path: str) -> None:
+    dm = DataManager(COLUMN_TYPES, database_path=db_path)
+    item_id = dm.add_item(
+        {
+            "name": f"item{idx}",
+            "count": idx,
+            "active": bool(idx % 2),
+            "rating": float(idx),
+            "tags": [idx, idx + 1],
+            "settings": {"idx": idx},
+        }
+    )
+    dm.set_attr(item_id, "count", idx * 10)
+    assert dm.get_attr(item_id, "count") == idx * 10
+    assert dm.find_item({"name": f"item{idx}"}) == (item_id,)
+    dm.rm_item(item_id)
+    assert dm.find_item({"name": f"item{idx}"}) == ()
+
+
+def test_datamanager_thread_safety_all_methods(tmp_path) -> None:
+    db_path = str(tmp_path / "dm_thread.db")
+    threads = [threading.Thread(target=_dm_worker, args=(i, db_path)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    dm = DataManager(COLUMN_TYPES, database_path=db_path)
+    assert dm.find_item() == ()
+
+
+# ---------------------------------------------------------------------------
+# TimerManager multi-thread tests
+
+
+def _tm_worker(idx: int, db_path: str) -> None:
+    tm = TimerManager(database_path=db_path)
+    timer_id = tm.create_timer(f"timer{idx}", duration=idx + 1)
+    assert tm.is_timer_running(timer_id)
+    tm.pause_timer(timer_id)
+    assert tm.is_timer_paused(timer_id)
+    tm.resume_timer(timer_id)
+    assert tm.is_timer_running(timer_id)
+    info = tm.get_timer_info(timer_id)
+    assert info["name"] == f"timer{idx}"
+    tm.rm_timer(timer_id)
+    assert not tm.is_timer_exists(timer_id)
+
+
+def test_timermanager_thread_safety(tmp_path) -> None:
+    db_path = str(tmp_path / "tm_thread.db")
+    threads = [threading.Thread(target=_tm_worker, args=(i, db_path)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    tm = TimerManager(database_path=db_path)
+    assert tm.dm.find_item() == ()
+


### PR DESCRIPTION
## Summary
- Refactor TimerManager to accept custom DB path and fix pause/resume logic
- Add comprehensive multithreaded tests for DataManager and TimerManager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68995b0c02908330af89c2198f16963c