### PR TITLE
Add asynchronous timer watcher with callback support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,25 @@
-"""Timer management utilities backed by :class:`DataManager`."""
+"""Timer management utilities backed by :class:`DataManager`.
 
-from typing import Any, Dict
+This module provides :class:`TimerManager` for manipulating timers stored in a
+SQLite database and :class:`TimerWatcher` which monitors those timers and fires
+callbacks when they expire.  The watcher runs in a background ``asyncio`` event
+loop so normal synchronous code can create timers without worrying about
+awaiting coroutine objects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
 import time
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from data import DataManager
 
 
 PAUSED = "paused"
 RUNNING = "running"
+FINISHED = "finished"
 NOT_SET = -1.0
 
 
@@ -33,7 +45,11 @@ class TimerManager:
             },
             database_path=database_path,
         )
-        self.watching_tasks = self.dm.find_item({"status": RUNNING})
+
+        # Registered callbacks are invoked with ``event`` and ``timer_id`` when
+        # timers are created, deleted or their state changes.  This is primarily
+        # used by :class:`TimerWatcher` but can also be hooked into by user code.
+        self._callbacks: List[Callable[[str, int], None]] = []
 
     def is_timer_exists(self, timer_id: int) -> bool:
         """Return ``True`` if ``timer_id`` exists in the database."""
@@ -69,6 +85,26 @@ class TimerManager:
         assert end_time == NOT_SET
         return True
 
+    def add_callback(self, callback: Callable[[str, int], None]) -> None:
+        """Register ``callback`` to be notified of timer events."""
+        if callback not in self._callbacks:
+            self._callbacks.append(callback)
+
+    # ------------------------------------------------------------------
+    def _notify(self, event: str, timer_id: int) -> None:
+        """Invoke callbacks for ``event`` affecting ``timer_id``.
+
+        Any exceptions raised by callbacks are suppressed so that timer
+        operations continue uninterrupted."""
+
+        for cb in list(self._callbacks):
+            try:
+                cb(event, timer_id)
+            except Exception:
+                # Callback misbehaviour should not break timer logic
+                pass
+
+    # ------------------------------------------------------------------
     def create_timer(self, name: str, duration: int) -> int:
         if not isinstance(name, str) or not isinstance(duration, int):
             raise ValueError("Name must be a string and duration must be an integer.")
@@ -80,7 +116,7 @@ class TimerManager:
             raise ValueError("Name cannot exceed 100 characters.")
         this_moment = time.time()
         float_duration = float(duration)
-        return self.dm.add_item(
+        timer_id = self.dm.add_item(
             {
                 "name": name,
                 "duration": float_duration,
@@ -89,10 +125,13 @@ class TimerManager:
                 "status": RUNNING,
             }
         )
+        self._notify("created", timer_id)
+        return timer_id
 
     def rm_timer(self, timer_id: int) -> None:
         assert self.is_timer_exists(timer_id)
         self.dm.rm_item(timer_id)
+        self._notify("deleted", timer_id)
 
     def pause_timer(self, timer_id: int) -> None:
         assert self.is_timer_exists(timer_id)
@@ -103,6 +142,7 @@ class TimerManager:
         self.dm.set_attr(timer_id, "start_time", NOT_SET)
         self.dm.set_attr(timer_id, "end_time", NOT_SET)
         self.dm.set_attr(timer_id, "status", PAUSED)
+        self._notify("paused", timer_id)
 
     def resume_timer(self, timer_id: int) -> None:
         assert self.is_timer_exists(timer_id)
@@ -115,6 +155,24 @@ class TimerManager:
         self.dm.set_attr(timer_id, "start_time", start_time)
         self.dm.set_attr(timer_id, "end_time", end_time)
         self.dm.set_attr(timer_id, "status", RUNNING)
+        self._notify("resumed", timer_id)
+
+    # ------------------------------------------------------------------
+    def mark_timer_finished(self, timer_id: int) -> None:
+        """Mark ``timer_id`` as finished.
+
+        The timer is not removed from the database; only its ``status`` field is
+        updated.  ``TimerWatcher`` calls this when a timer reaches its end.
+        """
+
+        if not self.is_timer_exists(timer_id):
+            return
+        # Only running timers can transition to finished
+        status = self.dm.get_attr(timer_id, "status")
+        if status == FINISHED:
+            return
+        self.dm.set_attr(timer_id, "status", FINISHED)
+        self._notify("finished", timer_id)
 
     def get_timer_info(self, timer_id: int) -> Dict[str, Any]:
         if not self.is_timer_exists(timer_id):
@@ -127,4 +185,147 @@ class TimerManager:
             "end_time": self.dm.get_attr(timer_id, "end_time"),
             "status": self.dm.get_attr(timer_id, "status"),
         }
+
+
+# ---------------------------------------------------------------------------
+# TimerWatcher
+
+
+class TimerWatcher:
+    """Monitor timers managed by :class:`TimerManager`.
+
+    The watcher keeps track of all running timers and waits for them to expire
+    in a background ``asyncio`` event loop.  When a timer finishes it is marked
+    as ``finished`` in the database and a user supplied callback is invoked.
+
+    Parameters
+    ----------
+    manager:
+        The :class:`TimerManager` instance to observe.
+    on_finished:
+        Callback invoked with ``timer_id`` when a timer reaches its end.  If not
+        provided a simple printer function is used.
+    """
+
+    def __init__(
+        self,
+        manager: TimerManager,
+        on_finished: Optional[Callable[[int], None]] = None,
+    ) -> None:
+        self._manager = manager
+        self._on_finished = on_finished or (lambda tid: print(f"Timer {tid} finished"))
+
+        # Dedicated asyncio loop in a daemon thread so synchronous code can
+        # continue executing while timers are monitored.  Because SQLite
+        # connections are not thread-safe, the watcher uses its own
+        # :class:`DataManager` instance backed by the same database file.
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+
+        # DataManager for use inside the watcher thread.  It must be constructed
+        # in that thread because SQLite connections are not thread-safe.  A
+        # blocking ``Event`` is used so that ``__init__`` waits until the
+        # connection is ready before proceeding.
+        self._worker_dm: Optional[DataManager] = None
+        ready = threading.Event()
+
+        async def _init_dm() -> None:
+            self._worker_dm = DataManager(
+                {
+                    "duration": float,
+                    "start_time": float,
+                    "end_time": float,
+                    "status": str,
+                    "name": str,
+                },
+                database_path=self._manager.dm._db_path,  # type: ignore[attr-defined]
+            )
+            ready.set()
+
+        asyncio.run_coroutine_threadsafe(_init_dm(), self._loop)
+        ready.wait()
+
+        # Map of timer_id -> Future returned by ``run_coroutine_threadsafe``.
+        self._tasks: Dict[int, asyncio.Future] = {}
+
+        # React to TimerManager events
+        self._manager.add_callback(self._handle_event)
+
+        # Start watching currently running timers
+        for tid in self._manager.dm.find_item({"status": RUNNING}):
+            self._schedule_watch(int(tid))
+
+    # ------------------------------------------------------------------
+    # Event handling
+    def _handle_event(self, event: str, timer_id: int) -> None:
+        if event in {"created", "resumed"}:
+            self._schedule_watch(timer_id)
+        elif event in {"paused", "deleted", "finished"}:
+            self._cancel_watch(timer_id)
+
+    # ------------------------------------------------------------------
+    def _schedule_watch(self, timer_id: int) -> None:
+        if timer_id in self._tasks:
+            return
+        coro = self._wait_for_timer(timer_id)
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        self._tasks[timer_id] = future
+
+    def _cancel_watch(self, timer_id: int) -> None:
+        fut = self._tasks.pop(timer_id, None)
+        if fut is not None:
+            fut.cancel()
+
+    async def _wait_for_timer(self, timer_id: int) -> None:
+        while True:
+            # Retrieve remaining time for the timer
+            try:
+                status = self._worker_dm.get_attr(timer_id, "status")
+                end_time = self._worker_dm.get_attr(timer_id, "end_time")
+            except ValueError:
+                # Timer no longer exists
+                return
+            if status != RUNNING:
+                return
+
+            now = time.time()
+            delay = max(0.0, end_time - now)
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+
+            # After waiting re-check that the timer is still valid and running
+            try:
+                status = self._worker_dm.get_attr(timer_id, "status")
+                end_time = self._worker_dm.get_attr(timer_id, "end_time")
+            except ValueError:
+                return
+            if status != RUNNING:
+                return
+
+            if time.time() >= end_time:
+                self._worker_dm.set_attr(timer_id, "status", FINISHED)
+                # Notify via the main manager so external callbacks fire
+                self._manager._notify("finished", timer_id)
+                self._on_finished(timer_id)
+                return
+            # Timer has been extended; loop and wait again for remaining time
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        """Cancel all tasks and stop the background event loop."""
+        for tid in list(self._tasks):
+            self._cancel_watch(tid)
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join()
+        try:
+            self._loop.close()
+        finally:
+            try:
+                if self._worker_dm is not None:
+                    self._worker_dm._conn.close()  # type: ignore[attr-defined]
+            except Exception:
+                pass
 

--- a/test_timer_watcher.py
+++ b/test_timer_watcher.py
@@ -1,0 +1,52 @@
+import time
+import time
+import time
+from typing import List
+
+import time
+from typing import List
+
+from main import TimerManager, TimerWatcher, PAUSED, FINISHED
+
+
+def test_watcher_marks_finished_and_callback(tmp_path):
+    db = str(tmp_path / "timers.db")
+    tm = TimerManager(database_path=db)
+    finished: List[int] = []
+    watcher = TimerWatcher(tm, finished.append)
+    tid = tm.create_timer("t1", 1)
+    time.sleep(1.3)
+    assert tm.dm.get_attr(tid, "status") == FINISHED
+    assert finished == [tid]
+    watcher.stop()
+
+
+def test_watcher_handles_pause_resume(tmp_path):
+    db = str(tmp_path / "timers_pause.db")
+    tm = TimerManager(database_path=db)
+    finished: List[int] = []
+    watcher = TimerWatcher(tm, finished.append)
+    tid = tm.create_timer("t1", 1)
+    time.sleep(0.3)
+    tm.pause_timer(tid)
+    assert tm.dm.get_attr(tid, "status") == PAUSED
+    time.sleep(0.5)
+    assert finished == []  # callback not triggered while paused
+    remaining = tm.dm.get_attr(tid, "duration")
+    tm.resume_timer(tid)
+    time.sleep(remaining + 0.3)
+    assert tm.dm.get_attr(tid, "status") == FINISHED
+    assert finished == [tid]
+    watcher.stop()
+
+
+def test_watcher_handles_deletion(tmp_path):
+    db = str(tmp_path / "timers_delete.db")
+    tm = TimerManager(database_path=db)
+    finished: List[int] = []
+    watcher = TimerWatcher(tm, finished.append)
+    tid = tm.create_timer("t1", 1)
+    tm.rm_timer(tid)
+    time.sleep(1.2)
+    assert finished == []
+    watcher.stop()


### PR DESCRIPTION
## Summary
- enhance `TimerManager` with callback registration and state-change notifications
- introduce `TimerWatcher` to monitor timers in a background event loop and mark expired timers as finished
- test watcher lifecycle including pause/resume and deletion scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689962a1d12c8330ad29fe7d232cd4c2