### PR TITLE
refactor: move timer callbacks to proxy

### DIFF
--- a/test/test_timer_watcher.py
+++ b/test/test_timer_watcher.py
@@ -1,20 +1,22 @@
 import time
-import time
-import time
 from typing import List
 
-import time
-from typing import List
-
-from main import TimerManager, TimerWatcher, PAUSED, FINISHED
+from main import (
+    TimerManager,
+    TimerManagerProxy,
+    TimerWatcher,
+    PAUSED,
+    FINISHED,
+)
 
 
 def test_watcher_marks_finished_and_callback(tmp_path):
     db = str(tmp_path / "timers.db")
     tm = TimerManager(database_path=db)
+    proxy = TimerManagerProxy(tm)
     finished: List[int] = []
-    watcher = TimerWatcher(tm, finished.append)
-    tid = tm.create_timer("t1", 1)
+    watcher = TimerWatcher(proxy, finished.append)
+    tid = proxy.create_timer("t1", 1)
     time.sleep(1.3)
     assert tm.dm.get_attr(tid, "status") == FINISHED
     assert finished == [tid]
@@ -24,16 +26,17 @@ def test_watcher_marks_finished_and_callback(tmp_path):
 def test_watcher_handles_pause_resume(tmp_path):
     db = str(tmp_path / "timers_pause.db")
     tm = TimerManager(database_path=db)
+    proxy = TimerManagerProxy(tm)
     finished: List[int] = []
-    watcher = TimerWatcher(tm, finished.append)
-    tid = tm.create_timer("t1", 1)
+    watcher = TimerWatcher(proxy, finished.append)
+    tid = proxy.create_timer("t1", 1)
     time.sleep(0.3)
-    tm.pause_timer(tid)
+    proxy.pause_timer(tid)
     assert tm.dm.get_attr(tid, "status") == PAUSED
     time.sleep(0.5)
     assert finished == []  # callback not triggered while paused
     remaining = tm.dm.get_attr(tid, "duration")
-    tm.resume_timer(tid)
+    proxy.resume_timer(tid)
     time.sleep(remaining + 0.3)
     assert tm.dm.get_attr(tid, "status") == FINISHED
     assert finished == [tid]
@@ -43,10 +46,11 @@ def test_watcher_handles_pause_resume(tmp_path):
 def test_watcher_handles_deletion(tmp_path):
     db = str(tmp_path / "timers_delete.db")
     tm = TimerManager(database_path=db)
+    proxy = TimerManagerProxy(tm)
     finished: List[int] = []
-    watcher = TimerWatcher(tm, finished.append)
-    tid = tm.create_timer("t1", 1)
-    tm.rm_timer(tid)
+    watcher = TimerWatcher(proxy, finished.append)
+    tid = proxy.create_timer("t1", 1)
+    proxy.rm_timer(tid)
     time.sleep(1.2)
     assert finished == []
     watcher.stop()


### PR DESCRIPTION
## Summary
- decouple callback handling from `TimerManager` via new `TimerManagerProxy`
- adjust `TimerWatcher` to subscribe through the proxy
- update watcher tests to use proxy API

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c039a2e308330b64b12be9227fbac