### PR TITLE
Handle proxy timers without initial timers and add callback test

### DIFF
--- a/test/test_proxy_callbacks_on_time.py
+++ b/test/test_proxy_callbacks_on_time.py
@@ -1,0 +1,34 @@
+import time
+from typing import List
+
+from timer_manager import TimerManager, TimerManagerProxy
+from history import TimerWatcher
+
+
+def test_proxy_callbacks_on_time(tmp_path):
+    db = str(tmp_path / "proxy.db")
+    tm = TimerManager(database_path=db)
+    proxy = TimerManagerProxy(tm)
+
+    events: List[tuple[int, float]] = []
+
+    def record(event: str, timer_id: int) -> None:
+        if event == "finished":
+            events.append((timer_id, time.time()))
+
+    proxy.add_callback(record)
+
+    watcher = TimerWatcher(proxy)
+
+    tid1 = proxy.create_timer("t1", 1)
+    tid2 = proxy.create_timer("t2", 2)
+
+    time.sleep(2.3)
+    watcher.stop()
+
+    assert [tid for tid, _ in events] == [tid1, tid2]
+
+    for tid, fired in events:
+        end_time = tm.dm.get_attr(tid, "end_time")
+        assert fired >= end_time
+        assert fired - end_time < 0.5


### PR DESCRIPTION
## Summary
- avoid crashes when TimerManagerProxy is created before any timers
- automatically reschedule proxy wait tasks after creating or deleting timers
- test proxy+watcher callback firing order and timing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d99773d7c8330bd4da2b893e732ca